### PR TITLE
app.go: rename unused param to `_`

### DIFF
--- a/app.go
+++ b/app.go
@@ -25,7 +25,7 @@ func main() {
 	}
 }
 
-func info(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+func info(w http.ResponseWriter, _ *http.Request, _ httprouter.Params) {
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 
 	info := struct {


### PR DESCRIPTION
There is already 1 unused param named `_`.
May call `r` with blank ident as well.

Found by gocritic, `unusedParam` check.